### PR TITLE
Add global app wrapper with reusable header

### DIFF
--- a/frontend/components/Header.js
+++ b/frontend/components/Header.js
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import Link from "next/link";
+
+export default function Header() {
+  const [search, setSearch] = useState("");
+  const categories = ["Electronics", "Fashion", "Home", "Books"];
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    // Implement search navigation here if needed
+  };
+
+  return (
+    <header className="header">
+      <div className="top">
+        <Link href="/" className="logo">
+          E-Commerce Hub
+        </Link>
+        <form onSubmit={handleSubmit} className="search">
+          <input
+            type="text"
+            placeholder="Search for products"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <button type="submit">Search</button>
+        </form>
+        <div className="icons">
+          <Link href="/cart" aria-label="Cart">
+            🛒
+          </Link>
+          <Link href="/login" aria-label="User">
+            👤
+          </Link>
+        </div>
+      </div>
+      <nav className="categories">
+        {categories.map((c) => (
+          <Link key={c} href={`/products?category=${encodeURIComponent(c)}`}>
+            {c}
+          </Link>
+        ))}
+      </nav>
+    </header>
+  );
+}

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -1,0 +1,11 @@
+import "../styles/globals.css";
+import Header from "../components/Header";
+
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <>
+      <Header />
+      <Component {...pageProps} />
+    </>
+  );
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,107 @@
+/* Reset */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root {
+  --primary-color: #2874F0;
+  --accent-color: #ff9f00;
+  --text-color: #212121;
+  --bg-color: #f1f3f6;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.header {
+  background-color: var(--primary-color);
+  color: #fff;
+}
+
+.header .top {
+  display: flex;
+  align-items: center;
+  padding: 8px 16px;
+}
+
+.header .logo {
+  font-weight: bold;
+  font-size: 1.5rem;
+  margin-right: 16px;
+  color: #fff;
+}
+
+.header .search {
+  flex: 1;
+  display: flex;
+}
+
+.header .search input {
+  flex: 1;
+  padding: 8px;
+  border: none;
+  border-radius: 2px 0 0 2px;
+}
+
+.header .search button {
+  padding: 8px 12px;
+  border: none;
+  background-color: var(--accent-color);
+  color: #fff;
+  border-radius: 0 2px 2px 0;
+  cursor: pointer;
+}
+
+.header .icons {
+  display: flex;
+  gap: 16px;
+  margin-left: 16px;
+}
+
+.header .icons a {
+  font-size: 1.2rem;
+  color: #fff;
+}
+
+.header .categories {
+  display: flex;
+  gap: 16px;
+  background-color: #fff;
+  padding: 8px 16px;
+}
+
+.header .categories a {
+  color: var(--text-color);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 600px) {
+  .header .top {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .header .search {
+    width: 100%;
+    margin-top: 8px;
+  }
+
+  .header .icons {
+    margin-top: 8px;
+  }
+
+  .header .categories {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Summary
- create custom `_app.js` that injects global styles and header
- add responsive header with logo, search, categories, cart and user links
- define Flipkart-inspired global colors, fonts and resets

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689225214130832fb3b8d8325b5842d7