### PR TITLE
feat: add hero banner and product grid

### DIFF
--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import styles from "../styles/index.module.css";
 
 export default function Home() {
   const [products, setProducts] = useState([]);
@@ -11,31 +12,80 @@ export default function Home() {
       .catch((err) => console.error("Error fetching products", err));
   }, []);
 
-  const categories = Array.from(new Set(products.map((p) => p.category).filter(Boolean)));
+  const categories = Array.from(
+    new Set(products.map((p) => p.category).filter(Boolean))
+  );
   const featured = products.slice(0, 4);
 
+  const banners = [
+    "https://via.placeholder.com/800x300?text=Banner+1",
+    "https://via.placeholder.com/800x300?text=Banner+2",
+    "https://via.placeholder.com/800x300?text=Banner+3",
+  ];
+  const [currentSlide, setCurrentSlide] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(
+      () => setCurrentSlide((prev) => (prev + 1) % banners.length),
+      3000
+    );
+    return () => clearInterval(interval);
+  }, [banners.length]);
+
   return (
-    <div>
-      <h1>E-Commerce Hub</h1>
-      <section>
-        <h2>Featured Products</h2>
-        <ul>
-          {featured.map((product) => (
-            <li key={product._id}>
-              <Link href={`/product/${product._id}`}>{product.name}</Link> - ${product.price}
-            </li>
-          ))}
-        </ul>
-      </section>
-      <section>
-        <h2>Categories</h2>
-        <ul>
+    <div className={styles.container}>
+      <div className={styles.hero}>
+        {banners.map((src, idx) => (
+          <img
+            key={src}
+            src={src}
+            alt={`Banner ${idx + 1}`}
+            className={`${styles.slide} ${
+              idx === currentSlide ? styles.active : ""
+            }`}
+          />
+        ))}
+      </div>
+
+      <section className={styles.categorySection}>
+        <div className={styles.categoryGrid}>
           {categories.map((category) => (
-            <li key={category}>{category}</li>
+            <div key={category} className={styles.categoryTile}>
+              {category}
+            </div>
           ))}
-        </ul>
+        </div>
       </section>
-      <Link href="/products">View All Products</Link>
+
+      <section className={styles.featuredSection}>
+        <h2 className={styles.sectionTitle}>Featured Products</h2>
+        <div className={styles.featuredGrid}>
+          {featured.map((product) => (
+            <Link
+              key={product._id}
+              href={`/product/${product._id}`}
+              className={styles.card}
+            >
+              <img
+                src={
+                  product.images?.[0] ||
+                  "https://via.placeholder.com/200?text=No+Image"
+                }
+                alt={product.name}
+                className={styles.cardImage}
+              />
+              <div className={styles.cardBody}>
+                <h3 className={styles.cardTitle}>{product.name}</h3>
+                <p className={styles.cardPrice}>${product.price}</p>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <Link href="/products" className={styles.viewAll}>
+        View All Products
+      </Link>
     </div>
   );
 }

--- a/frontend/styles/index.module.css
+++ b/frontend/styles/index.module.css
@@ -1,0 +1,104 @@
+.container {
+  padding: 1rem;
+}
+
+.hero {
+  position: relative;
+  height: 300px;
+  overflow: hidden;
+}
+
+.slide {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0;
+  transition: opacity 0.5s ease-in-out;
+}
+
+.active {
+  opacity: 1;
+}
+
+.categorySection {
+  margin-top: 1rem;
+}
+
+.categoryGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+}
+
+.categoryTile {
+  background-color: #2874f0;
+  color: #fff;
+  padding: 1rem;
+  text-align: center;
+  border-radius: 4px;
+}
+
+.categoryTile:nth-child(even) {
+  background-color: #ffe500;
+  color: #000;
+}
+
+.featuredSection {
+  margin-top: 2rem;
+}
+
+.sectionTitle {
+  margin-bottom: 1rem;
+  color: #2874f0;
+}
+
+.featuredGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  border: 1px solid #eee;
+  border-radius: 4px;
+  overflow: hidden;
+  background: #fff;
+  color: inherit;
+  transition: box-shadow 0.2s;
+}
+
+.card:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.cardImage {
+  width: 100%;
+  height: 150px;
+  object-fit: cover;
+}
+
+.cardBody {
+  padding: 0.5rem 1rem 1rem;
+}
+
+.cardTitle {
+  font-size: 1rem;
+  margin: 0 0 0.5rem;
+}
+
+.cardPrice {
+  margin: 0;
+  color: #388e3c;
+}
+
+.viewAll {
+  display: inline-block;
+  margin-top: 2rem;
+  color: #2874f0;
+}
+


### PR DESCRIPTION
## Summary
- add rotating hero banner carousel on home page
- display categories as Flipkart-colored tiles and products in grid cards
- extract inline styles to CSS modules

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint frontend/pages/index.js frontend/styles/index.module.css` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6892252550e8832f9668403e5ff6f477