### PR TITLE
style: enhance cart and auth pages

### DIFF
--- a/frontend/pages/cart.js
+++ b/frontend/pages/cart.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import styles from "../styles/cart.module.css";
 
 export default function Cart() {
   const [cart, setCart] = useState([]);
@@ -22,27 +23,69 @@ export default function Cart() {
     localStorage.setItem("cart", JSON.stringify(updated));
   };
 
-  const total = cart.reduce((sum, item) => sum + item.price * item.quantity, 0);
+  const total = cart.reduce(
+    (sum, item) => sum + item.price * item.quantity,
+    0
+  );
 
   return (
-    <div>
+    <div className={styles.container}>
       <h1>Shopping Cart</h1>
       {cart.length === 0 && <p>Your cart is empty</p>}
-      <ul>
-        {cart.map((item) => (
-          <li key={item._id}>
-            {item.name} - ${item.price} x
-            <input
-              type="number"
-              value={item.quantity}
-              min="1"
-              onChange={(e) => updateQuantity(item._id, e.target.value)}
-            />
-            <button onClick={() => removeItem(item._id)}>Remove</button>
-          </li>
-        ))}
-      </ul>
-      <p>Total: ${total.toFixed(2)}</p>
+      {cart.length > 0 && (
+        <>
+          <table className={styles.cartTable}>
+            <thead>
+              <tr>
+                <th>Product</th>
+                <th>Price</th>
+                <th>Quantity</th>
+                <th>Subtotal</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {cart.map((item) => (
+                <tr key={item._id}>
+                  <td className={styles.productCell}>
+                    {item.images?.[0] && (
+                      <img
+                        src={item.images[0]}
+                        alt={item.name}
+                        className={styles.thumb}
+                      />
+                    )}
+                    <span>{item.name}</span>
+                  </td>
+                  <td>${item.price}</td>
+                  <td>
+                    <input
+                      type="number"
+                      value={item.quantity}
+                      min="1"
+                      className={styles.quantityInput}
+                      onChange={(e) => updateQuantity(item._id, e.target.value)}
+                    />
+                  </td>
+                  <td>${(item.price * item.quantity).toFixed(2)}</td>
+                  <td>
+                    <button
+                      onClick={() => removeItem(item._id)}
+                      className={styles.removeButton}
+                    >
+                      Remove
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div className={styles.summary}>
+            <p>Total: ${total.toFixed(2)}</p>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import styles from "../styles/auth.module.css";
 
 export default function Login() {
   const [email, setEmail] = useState("");
@@ -21,21 +22,27 @@ export default function Login() {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <h1>Login</h1>
-      <input
-        type="email"
-        placeholder="Email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-      />
-      <input
-        type="password"
-        placeholder="Password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-      />
-      <button type="submit">Login</button>
-    </form>
+    <div className={styles.container}>
+      <form className={styles.card} onSubmit={handleSubmit}>
+        <h1>Login</h1>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className={styles.input}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className={styles.input}
+        />
+        <button type="submit" className={styles.button}>
+          Login
+        </button>
+      </form>
+    </div>
   );
 }

--- a/frontend/pages/signup.js
+++ b/frontend/pages/signup.js
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import styles from "../styles/auth.module.css";
 
 export default function Signup() {
   const [name, setName] = useState("");
@@ -21,27 +22,34 @@ export default function Signup() {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <h1>Signup</h1>
-      <input
-        type="text"
-        placeholder="Name"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-      />
-      <input
-        type="email"
-        placeholder="Email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-      />
-      <input
-        type="password"
-        placeholder="Password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-      />
-      <button type="submit">Signup</button>
-    </form>
+    <div className={styles.container}>
+      <form className={styles.card} onSubmit={handleSubmit}>
+        <h1>Signup</h1>
+        <input
+          type="text"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className={styles.input}
+        />
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className={styles.input}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className={styles.input}
+        />
+        <button type="submit" className={styles.button}>
+          Signup
+        </button>
+      </form>
+    </div>
   );
 }

--- a/frontend/styles/auth.module.css
+++ b/frontend/styles/auth.module.css
@@ -1,0 +1,39 @@
+.container {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #f1f3f6;
+}
+
+.card {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+}
+
+.input {
+  width: 100%;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.button {
+  width: 100%;
+  background: #2874f0;
+  color: #fff;
+  padding: 0.75rem;
+  border: none;
+  border-radius: 4px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.button:hover {
+  background: #0f5ba6;
+}

--- a/frontend/styles/cart.module.css
+++ b/frontend/styles/cart.module.css
@@ -1,0 +1,56 @@
+.container {
+  padding: 2rem;
+  background: #f1f3f6;
+  min-height: 100vh;
+}
+
+.cartTable {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+}
+
+.cartTable th {
+  background: #2874f0;
+  color: #fff;
+  text-align: left;
+}
+
+.cartTable th,
+.cartTable td {
+  padding: 1rem;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.productCell {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.thumb {
+  width: 60px;
+  height: 60px;
+  object-fit: cover;
+}
+
+.quantityInput {
+  width: 60px;
+  padding: 0.25rem;
+}
+
+.removeButton {
+  background: none;
+  border: none;
+  color: #2874f0;
+  cursor: pointer;
+}
+
+.summary {
+  margin-top: 2rem;
+  text-align: right;
+  background: #fff;
+  padding: 1rem 2rem;
+  border: 1px solid #e0e0e0;
+  display: inline-block;
+}


### PR DESCRIPTION
## Summary
- replace basic cart list with table layout featuring product thumbnails, quantity controls and totals card
- center login and signup forms inside cards using unified Flipkart-themed styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Couldn't find any `pages` or `app` directory)*

------
https://chatgpt.com/codex/tasks/task_e_6892252bc730832f9ae6a81ff43c2854